### PR TITLE
Fix the include directory in pkgconfig.

### DIFF
--- a/vvas-gst-plugins/pkgconfig/vvas-gst-plugins.pc.in
+++ b/vvas-gst-plugins/pkgconfig/vvas-gst-plugins.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@/gstreamer-1.0
 
 Name: VVAS Gstreamer Library
 Description: VVAS Gstreamer Library Implementation


### PR DESCRIPTION
Hi,

The default pkgconfig include path do not align with the actual install path in vvast-gst-plugins/gst-libs/gst/vvas/meson.build. This commit align the pkgconfig include path with the make file

Regards,
Hon-Ming